### PR TITLE
docs: add AGENTS.md back-pointer to the Vega knowledge base

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# vdk-flux — AGENTS.md
+
+This is a **Vega** repository. Cross-cutting truth (constitutions, engineering
+standards, architecture records, the repo registry) lives in the canonical
+knowledge base: **`ArchetypicalSoftware/projects`** (locally
+`C:\projects\Archetypical\projects`). Read its root `AGENTS.md` first.
+
+Before working here:
+- Follow the [engineering standards](https://github.com/ArchetypicalSoftware/projects/blob/main/governance/standards/vega-platform-engineering-standards.md)
+  and the [IDP Constitution](https://github.com/ArchetypicalSoftware/projects/blob/main/governance/constitutions/archetypical-idp-constitution.md).
+- This repo's architecture record (create if missing):
+  `projects/governance/architecture/vdk-flux.md` — keep it in sync when you change
+  how this repo is built or wired, and add/refresh its row in
+  `projects/governance/registry.md`.
+
+Repo-specific docs: see this repository's `README.md` / `docs/`.


### PR DESCRIPTION
Adds the root `AGENTS.md` back-pointer required by the [governance mandate](https://github.com/ArchetypicalSoftware/projects/blob/main/AGENTS.md) in `ArchetypicalSoftware/projects`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)